### PR TITLE
Bug Fixes for POST and PUT methods

### DIFF
--- a/src/controllers/answers.ts
+++ b/src/controllers/answers.ts
@@ -19,7 +19,7 @@ async function post(request: express.Request, response: express.Response): Promi
             "postId": request.body.postId,
             "userId": request.body.userId,
             "content": request.body.content,
-            "timestamp": now.toISOString(),
+            "updated": now.toISOString(),
             "likes": 0
         }
 
@@ -109,7 +109,7 @@ async function put(request: express.Request, response: express.Response): Promis
             "postId": request.body.postId,
             "userId": request.body.userId,
             "content": request.body.content,
-            "timestamp": now.toISOString(),
+            "updated": now.toISOString(),
             "likes": request.body.likes
         }
 

--- a/src/controllers/answers.ts
+++ b/src/controllers/answers.ts
@@ -25,7 +25,7 @@ async function post(request: express.Request, response: express.Response): Promi
 
         const answer = await Answer.create(document);
 
-        response.status(201).send(document);
+        response.status(201).send(answer);
     }
     catch (error: any) {
         response.status(500).send(error.message);

--- a/src/controllers/comments.ts
+++ b/src/controllers/comments.ts
@@ -26,7 +26,7 @@ async function post(request: express.Request, response: express.Response): Promi
 
         const comment = await Comment.create(document);
 
-        response.status(201).send(document);
+        response.status(201).send(comment);
     }
     catch (error: any) {
         response.status(500).send(error.message);

--- a/src/controllers/comments.ts
+++ b/src/controllers/comments.ts
@@ -20,7 +20,7 @@ async function post(request: express.Request, response: express.Response): Promi
             "userId": request.body.userId,
             "content": request.body.content,
             "parent": request.body.parent,
-            "timestamp": now.toISOString(),
+            "updated": now.toISOString(),
             "likes": 0
         }
 
@@ -112,7 +112,7 @@ async function put(request: express.Request, response: express.Response): Promis
             "userId": request.body.userId,
             "content": request.body.content,
             "parent": request.body.parent,
-            "timestamp": now.toISOString(),
+            "updated": now.toISOString(),
             "likes": request.body.likes
         }
 

--- a/src/controllers/posts.ts
+++ b/src/controllers/posts.ts
@@ -20,7 +20,7 @@ async function post(request: express.Request, response: express.Response): Promi
 
         const post = await Post.create(document);
 
-        response.status(201).send(document);
+        response.status(201).send(post);
     }
     catch (error: any) {
         response.status(500).send(error.message);

--- a/src/controllers/posts.ts
+++ b/src/controllers/posts.ts
@@ -14,7 +14,7 @@ async function post(request: express.Request, response: express.Response): Promi
             "userId": request.body.userId,
             "title": request.body.title,
             "question": request.body.question,
-            "timestamp": now.toISOString(),
+            "updated": now.toISOString(),
             "likes": 0
         }
 
@@ -88,7 +88,7 @@ async function put(request: express.Request, response: express.Response): Promis
             "userId": request.body.userId,
             "title": request.body.title,
             "question": request.body.question,
-            "timestamp": now.toISOString(),
+            "updated": now.toISOString(),
             "likes": request.body.likes
         }
 

--- a/src/controllers/users.ts
+++ b/src/controllers/users.ts
@@ -22,7 +22,6 @@ async function post(request: express.Request, response: express.Response): Promi
             "email": request.body.email,
             "organization": request.body.organization,
             "permissions": request.body.permissions,
-            "created": now.toISOString(),
             "updated": now.toISOString(),
             "likes": 0
         }
@@ -133,7 +132,6 @@ async function put(request: express.Request, response: express.Response): Promis
             "email": request.body.email,
             "organization": request.body.organization,
             "permissions": request.body.permissions,
-            "created": request.body.created,
             "updated": now.toISOString(),
             "likes": request.body.likes
         }

--- a/src/models/answers.ts
+++ b/src/models/answers.ts
@@ -1,10 +1,11 @@
 import { Schema, Types, model } from 'mongoose';
 
+// Note that the created timestamp is incorporated into the MongoDB ObjectId and can be extracted.
 interface IAnswer {
     postId: Types.ObjectId;
     userId: Types.ObjectId;
     content: string;
-    timestamp: string;  // Date/Time in ISO 8601 format
+    updated: string;  // Date/Time in ISO 8601 format
     likes: number;
 }
 
@@ -12,7 +13,7 @@ const answerSchema = new Schema<IAnswer>({
     postId: { type: Schema.Types.ObjectId, required: true },
     userId: { type: Schema.Types.ObjectId, required: true },
     content: { type: String, required: true },
-    timestamp: { type: String, required: true },
+    updated: { type: String, required: true },
     likes: { type: Number }
 });
 

--- a/src/models/comments.ts
+++ b/src/models/comments.ts
@@ -1,10 +1,11 @@
 import { Schema, Types, model } from 'mongoose';
 
+// Note that the created timestamp is incorporated into the MongoDB ObjectId and can be extracted.
 interface IComment {
     userId: Types.ObjectId;
     content: string;
     parent: Types.ObjectId;     // Post ID or Answer ID
-    timestamp: string;  // Date/Time in ISO 8601 format
+    updated: string;  // Date/Time in ISO 8601 format
     likes: number;
 }
 
@@ -12,7 +13,7 @@ const commentSchema = new Schema<IComment>({
     userId: { type: Schema.Types.ObjectId, required: true },
     content: { type: String, required: true },
     parent: { type: Schema.Types.ObjectId },
-    timestamp: { type: String, required: true },
+    updated: { type: String, required: true },
     likes: { type: Number }
 });
 

--- a/src/models/posts.ts
+++ b/src/models/posts.ts
@@ -1,10 +1,11 @@
 import { Schema, Types, model } from 'mongoose';
 
+// Note that the created timestamp is incorporated into the MongoDB ObjectId and can be extracted.
 interface IPost {
     userId: Types.ObjectId;
     title: string;
     question: string;
-    timestamp: string;  // Date/Time in ISO 8601 format
+    updated: string;  // Date/Time in ISO 8601 format
     likes: number;
 }
 
@@ -12,7 +13,7 @@ const postSchema = new Schema<IPost>({
     userId: { type: Schema.Types.ObjectId, required: true },
     title: { type: String, required: true },
     question: { type: String, required: true },
-    timestamp: { type: String },
+    updated: { type: String, required: true },
     likes: { type: Number }
 });
 

--- a/src/models/users.ts
+++ b/src/models/users.ts
@@ -1,5 +1,6 @@
 import { Schema, Types, model } from 'mongoose';
 
+// Note that the created timestamp is incorporated into the MongoDB ObjectId and can be extracted.
 interface IUser {
     lastName: string;
     firstName: string;
@@ -7,7 +8,6 @@ interface IUser {
     email: string;
     organization: string;
     permissions: any[];
-    created: string;    // Timestamp in ISO 8601 format
     updated: string;    // Timestamp in ISO 8601 format
     likes: number;
 }
@@ -19,7 +19,6 @@ const userSchema = new Schema<IUser>({
     email:  { type: String, required: true },
     organization: { type: String },
     permissions: [{ type: Schema.Types.Mixed, required: true}],
-    created: { type: String },
     updated: { type: String },
     likes: { type: Number }
 });

--- a/swagger.json
+++ b/swagger.json
@@ -400,8 +400,11 @@
           }
         ],
         "responses": {
-          "501": {
-            "description": "Not Implemented"
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -570,8 +573,11 @@
           }
         ],
         "responses": {
-          "501": {
-            "description": "Not Implemented"
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -591,8 +597,11 @@
           }
         ],
         "responses": {
-          "501": {
-            "description": "Not Implemented"
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -722,9 +731,6 @@
                 "permissions": {
                   "example": "any"
                 },
-                "created": {
-                  "example": "any"
-                },
                 "likes": {
                   "example": "any"
                 }
@@ -791,8 +797,11 @@
           }
         ],
         "responses": {
-          "501": {
-            "description": "Not Implemented"
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -812,8 +821,11 @@
           }
         ],
         "responses": {
-          "501": {
-            "description": "Not Implemented"
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }


### PR DESCRIPTION
- Change code to ensure that all POST methods return the ObjectId of the new document.
- Remove creation timestamp in Users POST and PUT.  The ObjectId contains the creation timestamp.
- Change the generic "timestamp" field in Posts, Answers, and Comments, to a more specific "updated" timestamp field.