### PR TITLE
Manual step due to swagger-autogen bug.

### DIFF
--- a/src/swagger.json
+++ b/src/swagger.json
@@ -91,7 +91,7 @@
     "/posts/": {
       "post": {
         "tags": [
-          " "
+          "posts"
         ],
         "description": "",
         "parameters": [


### PR DESCRIPTION
There is apparently a bug in swagger-autogen that puts a blank in the posts POST verb tag instead of "posts".  This is currently manifest on line 94 of swagger.json after it is generated.  One has to manually change the " " in the "tags" array to "posts" for the POST endpoint to show up in the `posts` section.

I have fought with this and googled for solutions but so far to no avail.