### PR TITLE
Convert jest.config to TypeScript

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,4 +1,6 @@
-module.exports = {
+import type {Config} from 'jest';
+
+const config: Config = {
     "testEnvironment": 'node',
     "roots": [
       "<rootDir>/src"
@@ -12,3 +14,4 @@ module.exports = {
     },
   }
   
+  export default config;


### PR DESCRIPTION
Convert jest.config.js => jest.config.ts

Import Config type
Define config constant of Config type
Export config

Completes "Mastery" (100%) grading rubric for Extra Credit TypeScript: Not one .js file in project.